### PR TITLE
build: add Makefile to build project; add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,88 @@
+# Compiled Object files
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# CMake
+CMakeCache.txt
+CMakeFiles/
+CMakeScripts/
+Testing/
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+
+# Build directories
+build/
+dist/
+out/
+
+# IDE and editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+Thumbs.db
+
+# Coverage reports
+*.gcno
+*.gcda
+*.gcov
+coverage.info
+coverage/
+
+# Valgrind output
+*.memcheck
+vgcore.*
+
+# Core dumps
+core
+core.*
+
+# Temporary files
+*.tmp
+*.temp
+*.log
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,85 @@
+NAME = cub3d
+CC = cc
+CFLAGS = -Wall -Wextra -Werror
+
+UNAME_S := $(shell uname -s)
+
+MLX_DIR = libs/minilibx-linux
+MLX_LIB = $(MLX_DIR)/libmlx.a
+# got minilibx from here: https://github.com/42paris/minilibx-linux/tree/master
+
+ifeq ($(UNAME_S), Linux)
+	MLX_LIB = $(MLX_DIR)/libmlx.a
+	MLX_FLAGS = -L$(MLX_DIR) -lmlx -lXext -lX11 -lm
+	INCLUDES = -I./includes -I$(MLX_DIR) -I$(LIBFT_DIR)
+else ifeq ($(UNAME_S), Darwin)
+	MLX_LIB = $(MLX_DIR)/libmlx_Darwin.a
+	MLX_FLAGS = -L$(MLX_DIR) -L/opt/X11/lib -L/usr/X11/include/../lib -lmlx -lXext -lX11 -lm -framework OpenGL -framework AppKit
+	INCLUDES = -I./includes -I$(MLX_DIR) -I$(LIBFT_DIR) -I/opt/X11/include -I/usr/X11/include
+else
+	$(error Unsupported operating system: $(UNAME_S))
+endif
+
+LIBFT_DIR = libs/libft
+LIBFT = $(LIBFT_DIR)/libft.a
+
+SRC_DIR = src/
+OBJ_DIR = obj/
+SRC_FILES =\
+
+
+SRCS = $(addprefix $(SRC_DIR), $(SRC_FILES))
+OBJS = $(patsubst $(SRC_DIR)%.c, $(OBJ_DIR)%.o, $(SRCS))
+
+OBJ_FLAG = .cache_exists
+
+all: $(NAME)
+
+$(MLX_LIB): $(MLX_DIR)
+	@echo "Building minilibX..."
+	@cd $(MLX_DIR) && ./configure && make
+
+
+$(LIBFT): $(LIBFT_DIR)
+	@echo "Building libft..."
+	@make -C$(LIBFT_DIR)
+	@echo "Libft ready"
+
+$(OBJ_DIR):
+	@mkdir obj
+
+$(OBJ_FLAG):
+	@touch $(OBJ_FLAG)
+
+$(OBJ_DIR)%.o: $(SRC_DIR)%.c | $(OBJ_FLAG)
+	@$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@ 
+
+
+$(NAME): $(MLX_LIB) $(LIBFT) $(OBJ_DIR) $(OBJS)
+	@echo "Compiling..."
+	@$(CC) $(CFLAGS) $(OBJS) $(MLX_FLAGS) -L$(LIBFT_DIR) -lft -o $(NAME)
+	@echo "FdF ready"
+
+clean:
+	@rm -rf $(OBJ_DIR)
+	@rm -f $(OBJ_FLAG)
+	@if [ -f $(MLX_DIR)/Makefile ]; then make -C $(MLX_DIR) clean 2>/dev/null || true; fi
+	@make -C $(LIBFT_DIR) clean
+
+fclean: clean
+	rm -f $(NAME)
+	@if [ -f $(MLX_DIR)/Makefile ]; then \
+		make -C $(MLX_DIR) fclean 2>/dev/null || \
+		make -C $(MLX_DIR) clean 2>/dev/null || \
+		rm -f $(MLX_DIR)/%.a $(MLX_DIR)/%.o 2>/dev/null || true; \
+	fi
+	@make -C $(LIBFT_DIR) fclean
+
+re: fclean all
+
+debug:
+	@echo "Detected OS: $(UNAME_S)"
+	@echo "Detected Architecture: $(UNAME_M)"
+	@echo "Using MinilibX directory: $(MLX_DIR)"
+
+.PHONY: all clean fclean re debug


### PR DESCRIPTION
Add a Makefile to build the cub3d executable. 
Key details:
- OS detection to choose MinilibX library and flags.
- Targets for building libs: $(MLX_LIB) and $(LIBFT).
- Object directory creation and pattern rule for compiling .c to .o.
- all, clean, fclean, re and debug phony targets.
- Uses an .cache_exists file to gate object compilation.
- Hard-coded variables for compiler, flags, source/obj dirs and names.
chore: add .gitignore