### PR TITLE
feat: add basic header; update: .gitignore; fix: MLX folder creation …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,6 @@ CMakeCache.txt
 CMakeFiles/
 CMakeScripts/
 Testing/
-Makefile
 cmake_install.cmake
 install_manifest.txt
 compile_commands.json

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ LIBFT = $(LIBFT_DIR)/libft.a
 SRC_DIR = src/
 OBJ_DIR = obj/
 SRC_FILES =\
+		main.c
 
 
 SRCS = $(addprefix $(SRC_DIR), $(SRC_FILES))
@@ -34,6 +35,11 @@ OBJS = $(patsubst $(SRC_DIR)%.c, $(OBJ_DIR)%.o, $(SRCS))
 OBJ_FLAG = .cache_exists
 
 all: $(NAME)
+
+$(MLX_DIR):
+	@echo "Cloning minilibX..."
+	@mkdir -p libs
+	@git clone https://github.com/42paris/minilibx-linux.git $(MLX_DIR)
 
 $(MLX_LIB): $(MLX_DIR)
 	@echo "Building minilibX..."
@@ -58,7 +64,7 @@ $(OBJ_DIR)%.o: $(SRC_DIR)%.c | $(OBJ_FLAG)
 $(NAME): $(MLX_LIB) $(LIBFT) $(OBJ_DIR) $(OBJS)
 	@echo "Compiling..."
 	@$(CC) $(CFLAGS) $(OBJS) $(MLX_FLAGS) -L$(LIBFT_DIR) -lft -o $(NAME)
-	@echo "FdF ready"
+	@echo "CUB3D ready"
 
 clean:
 	@rm -rf $(OBJ_DIR)
@@ -74,6 +80,7 @@ fclean: clean
 		rm -f $(MLX_DIR)/%.a $(MLX_DIR)/%.o 2>/dev/null || true; \
 	fi
 	@make -C $(LIBFT_DIR) fclean
+	@rm -rf $(MLX_DIR)
 
 re: fclean all
 

--- a/includes/cub3d.h
+++ b/includes/cub3d.h
@@ -1,0 +1,19 @@
+#ifndef CUB3D_H
+# define CUB3D_H
+
+# include <stdlib.h>
+# include <math.h>
+# include <X11/X.h>
+# include <X11/keysym.h>
+# include <fcntl.h>
+# include <errno.h>
+# include <stdio.h>
+# include "../libs/minilibx-linux/mlx.h"
+// # include "../libs/libft/includes/libft.h"
+// # include "../libs/libft/includes/get_next_line.h"
+// # include "../libs/libft/includes/ft_printf.h"
+
+# define WIDTH 1024
+# define HEIGHT 768
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -1,0 +1,10 @@
+#include "cub3d.h"
+
+int main(int argc, char **argv)
+{
+	(void)argc;
+	(void)argv;
+	
+	printf("Cub3D starting...\n");
+	return (0);
+}


### PR DESCRIPTION
…in Makefile

fix: improve Makefile dependency handling and add basic project structure

- Add auto-creation and auto-deletion of MinilibX directory in Makefile
- Update .gitignore (remove Makefile from it)
- Add basic main function placeholder
- Add header file

Libft can be stored in libs directory.
chore(make): update build messages and remove MLX dir on fclean